### PR TITLE
Sanitize iOS Inputs and Remove the Use of Eval

### DIFF
--- a/.github/workflows/codeql-ios.yml
+++ b/.github/workflows/codeql-ios.yml
@@ -42,6 +42,34 @@ jobs:
     steps:     
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      
+      #ADD INPUT VALIDATION SCRIPT
+      - name: Validate inputs
+        shell: python
+        env:
+          PROJECT: ${{ inputs.project }}
+          SCHEME: ${{ inputs.scheme }}
+          WORKSPACE: ${{ inputs.workspace }}
+        run: |
+          import os, sys
+
+          ALLOWED_PROJECTS = ("SampleApps/SPMTest/SPMTest.xcodeproj",)
+          ALLOWED_SCHEMES = ("SPMTest",)
+          ALLOWED_WORKSPACES = ("Braintree.xcworkspace",)
+
+          project = os.getenv("PROJECT")
+          scheme = os.getenv("SCHEME")
+          workspace = os.getenv("WORKSPACE")
+
+          if project not in ALLOWED_PROJECTS:
+              raise SystemExit(f"Invalid project: {project}. Allowed: {ALLOWED_PROJECTS}")
+          if scheme not in ALLOWED_SCHEMES:
+              raise SystemExit(f"Invalid scheme: {scheme}. Allowed: {ALLOWED_SCHEMES}")
+          if workspace and workspace not in ALLOWED_WORKSPACES:
+              raise SystemExit(f"Invalid workspace: {workspace}. Allowed: {ALLOWED_WORKSPACES}")
+
+          print("Inputs validated successfully.")
+
 
       - name: Resolve SPM Dependencies
         run: swift package resolve
@@ -74,9 +102,8 @@ jobs:
           args+=("clean")
           args+=("build")
           
-          build_cmd="xcodebuild ${args[*]}"
-          echo "${build_cmd}"
-          eval "${build_cmd}"
+          echo "Building with sanitized inputs..."
+          xcodebuild "${args[@]}"
                
       - name: Perform CodeQL Analysis
         id: codeql


### PR DESCRIPTION
Since this is a public repo, this is needed to limit the scope of actions-based injection attacks.