### PR TITLE
Add push event for main push without PR (release)

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   dependency-review:
     name: Dependency Review
-    if: ${{ github.event_name == 'pull_request' }}
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
@@ -26,9 +26,11 @@ jobs:
           context: ${{ env.STATUS_NAME }}
 
       - name: Checkout repository
+        if: github.event_name == 'pull_request'
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
   
-      - name: Dependency review       
+      - name: Dependency review
+        if: github.event_name == 'pull_request'       
         uses: actions/dependency-review-action@67d4f4bd7a9b17a0db54d2a7519187c65e339de8
         with:
           fail-on-severity: critical


### PR DESCRIPTION
This is to solve an issue when releasing ios and android versions of the SDK.