### PR TITLE
Add Push Event to Dependency Review Gradle for Push on Main

### DIFF
--- a/.github/workflows/dependency-review-gradle.yml
+++ b/.github/workflows/dependency-review-gradle.yml
@@ -17,6 +17,7 @@ permissions:
 jobs:
   dependency-review:
     name: Dependency Review
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
@@ -35,6 +36,7 @@ jobs:
           context: ${{ env.STATUS_NAME }}
 
       - name: Checkout Repository
+        if: github.event_name == 'pull_request'
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Setup Java
@@ -48,7 +50,7 @@ jobs:
         uses: gradle/actions/dependency-submission@06832c7b30a0129d7fb559bcc6e43d26f6374244
 
       - name: Dependency Review
-        if: ${{ github.event_name == 'pull_request' }}
+        if: github.event_name == 'pull_request'
         uses: actions/dependency-review-action@67d4f4bd7a9b17a0db54d2a7519187c65e339de8
         with:
           fail-on-severity: critical


### PR DESCRIPTION
This PR fixes the check failing when releasing a new version of the android SDK since they push tags from main.